### PR TITLE
feat: Implement collection playback and optimize history display

### DIFF
--- a/public/player.html
+++ b/public/player.html
@@ -195,6 +195,15 @@
     }
     /* End Status Message Styling */
 
+    .playlist-meta {
+        font-size: 0.9em;
+        color: #666; /* Adjusted for better visibility on light background */
+        margin: 2px 0;
+    }
+    #playlist-info {
+        margin-bottom: 5px;
+    }
+
     .error-message {
       background-color: #fdecea;
       color: #c62828;
@@ -232,6 +241,10 @@
     <div class="status-message" id="status-message"></div> <!-- Changed from error-message for generic use -->
     
     <div class="video-info">
+      <div id="playlist-info" style="display: none;">
+        <p id="playlist-name" class="playlist-meta"></p>
+        <p id="playlist-track-indicator" class="playlist-meta"></p>
+      </div>
       <div class="video-title" id="video-title">加载中...</div>
       <div class="video-id" id="video-id"></div>
     </div>
@@ -241,6 +254,12 @@
     <div class="custom-controls">
       <button class="play-pause" id="play-pause-btn">
         <i class="icon-play" id="play-icon"></i>
+      </button>
+      <button id="prev-track-btn" class="icon-btn" title="上一首" style="display: none;">
+        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M7 6 L7 18 L5 18 L5 6 L7 6 Z M17 6 L17 18 L15 12 L17 6 Z"/></svg>
+      </button>
+      <button id="next-track-btn" class="icon-btn" title="下一首" style="display: none;">
+        <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M17 6 L17 18 L19 18 L19 6 L17 6 Z M7 6 L7 18 L9 12 L7 6 Z"/></svg>
       </button>
       
       <div class="progress-container" id="progress-container">

--- a/public/popup.html
+++ b/public/popup.html
@@ -57,13 +57,27 @@
     button:hover {
       background-color: #e45f8a;
     }
-    button#play-current-btn, button#clear-history-btn { /* Standardize secondary buttons */
+    button#play-current-btn, button#clear-history-btn { 
         padding: 8px 12px;
         font-size: 12px;
-        width: auto; /* Allow them to not be full width if they are inline or part of a group */
+        width: auto; 
     }
-    button#clear-history-btn { /* If it should be full width like primary button */
+    /* button#clear-history-btn { 
         width: 100%; 
+    } */ /* Removed to allow side-by-side buttons */
+    .secondary-btn { /* Added for new buttons */
+        background-color: #6c757d; 
+        color: white;
+        border: none;
+        padding: 8px 12px; 
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px; 
+        transition: background-color 0.3s;
+        width: auto; 
+    }
+    .secondary-btn:hover {
+        background-color: #5a6268;
     }
     button:disabled {
       background-color: #cccccc;
@@ -129,6 +143,57 @@
       margin-bottom: 5px;
       word-break: break-all;
     }
+
+    /* Add these styles to popup.html's <style> section */
+    .container-section {
+      margin-bottom: 20px; 
+    }
+    .container-section h2 {
+      font-size: 16px; 
+      color: #fb7299; 
+      border-bottom: 1px solid #eee; 
+      padding-bottom: 8px; 
+      margin-bottom: 10px; 
+    }
+    #collection-list {
+      list-style-type: none;
+      padding-left: 0;
+      max-height: 150px; 
+      overflow-y: auto;
+    }
+    .collection-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 5px; 
+      border-bottom: 1px solid #f0f0f0;
+      cursor: pointer;
+      font-size: 13px;
+    }
+    .collection-item:hover {
+      background-color: #f5f5f5;
+    }
+    .collection-item:last-child {
+      border-bottom: none;
+    }
+    .collection-title {
+      flex-grow: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-right: 10px;
+    }
+    .collection-timestamp {
+      font-size: 11px;
+      color: #888;
+      white-space: nowrap;
+    }
+    .no-collections { 
+        text-align: center;
+        color: #666;
+        font-size: 13px;
+        padding: 10px 0;
+    }
   </style>
 </head>
 <body>
@@ -148,12 +213,22 @@
     <button id="extract-btn">提取并播放音频</button>
     <div id="status" class="status"></div>
 
+    <div id="collections-section" class="container-section">
+      <h2>播放合集</h2>
+      <ul id="collection-list">
+        <!-- Collection items will be populated here -->
+      </ul>
+    </div>
+
     <div id="history-section" class="container-section">
       <h2>播放历史</h2>
       <ul id="history-list">
         <!-- History items will be populated here -->
       </ul>
-      <button id="clear-history-btn" class="secondary-btn">清空播放历史</button>
+      <div class="history-footer" style="margin-top: 10px; display: flex; justify-content: space-between; align-items: center;">
+        <button id="more-history-btn" class="secondary-btn" style="display: none; font-size: 12px; padding: 6px 10px;">查看更多</button>
+        <button id="clear-history-btn" class="secondary-btn" style="font-size: 12px; padding: 6px 10px;">清空历史</button>
+    </div>
     </div>
     
     <div class="footer">

--- a/public/settings.html
+++ b/public/settings.html
@@ -132,6 +132,45 @@
         padding: 15px;
     }
     /* End of Playlist Management Styles */
+
+    /* Styles for Full History */
+    #full-history-list {
+      list-style-type: none;
+      padding: 0;
+      max-height: 450px; /* Adjust as needed */
+      overflow-y: auto;
+      border: 1px solid #eee; /* Optional border around the list */
+      border-radius: 4px;
+    }
+    .full-history-item {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 12px; /* Slightly more padding than popup */
+      border-bottom: 1px solid #f0f0f0; /* Separator line */
+      cursor: pointer;
+      background-color: #fff;
+    }
+    .full-history-item:last-child {
+      border-bottom: none; /* No line for the last item */
+    }
+    .full-history-item:hover {
+      background-color: #f9f9f9;
+    }
+    .full-history-title {
+      font-weight: 500; /* Or normal if preferred */
+      flex-grow: 1;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-right: 15px; /* More spacing */
+    }
+    .full-history-timestamp {
+      font-size: 0.9em;
+      color: #555; /* Slightly darker than popup for better readability on settings bg */
+      white-space: nowrap;
+    }
+    /* End of Full History Styles */
   </style>
 </head>
 <body>
@@ -176,6 +215,14 @@
     <ul id="playlist-items-list">
       <!-- Playlist items will be rendered here -->
     </ul>
+  </div>
+
+  <div class="container" id="full-history-section" style="margin-top: 20px;">
+    <h2>播放历史记录</h2>
+    <ul id="full-history-list">
+      <!-- Full history items will be populated here -->
+    </ul>
+    <p id="no-full-history-message" style="display:none; text-align:center; color: #666; padding: 15px;">暂无播放历史记录。</p>
   </div>
 
   <script src="settings.js"></script>


### PR DESCRIPTION
This commit introduces several new features and improvements:

1.  **Collection Display in Popup:**
    - Playlists (collections) are now displayed in the popup window, styled similarly to history items.
    - Each collection item shows its name and last update time.

2.  **Collection Playback:**
    - Clicking a collection item in the popup opens the player in playlist mode.
    - The player now supports playing through a list of audio items.
    - UI elements for playlist name, current track indicator (e.g., "Track X of Y"), and Next/Previous track buttons have been added to the player.
    - Playback automatically proceeds to the next track in the collection.

3.  **Optimized History Display in Popup:**
    - The history list in the popup is now limited to the 6 most recent items.
    - A "查看更多历史" (View More History) button appears if there are more than 6 items, linking to the settings page.

4.  **Full History Display in Settings:**
    - The settings page now includes a section displaying the complete playback history.
    - History items in this list are clickable to replay the audio.

These changes address your request to add collection functionality and improve history interaction. The player's ability to handle both single audio items and collections is maintained.